### PR TITLE
feat/added custom context karma file for polyfill

### DIFF
--- a/commands/unit/action.js
+++ b/commands/unit/action.js
@@ -69,6 +69,9 @@ function getConfig(app, options) {
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
         browsers: [],
 
+        // customContextFile if any
+        customContextFile: options.customContextFile ? options.customContextFile : null,
+
         plugins: [
             require('karma-mocha'),
             require('karma-mocha-reporter'),
@@ -204,6 +207,9 @@ module.exports = (app, options = {}) => {
         }
     }
 
+    // Handle Karma custom context file option
+    const customContextFile = options['context'];
+
     if (!process.env.hasOwnProperty('NODE_ENV')) {
         // Set NODE_ENV environment variable.
         app.log(colors.yellow('🔍 setting "test" environment.'));
@@ -280,6 +286,7 @@ module.exports = (app, options = {}) => {
                             server: options.server,
                             coverage: options.coverage,
                             targets: options.targets,
+                            customContextFile,
                             [taskEnvName]: true,
                         });
                     } catch (err) {

--- a/commands/unit/index.js
+++ b/commands/unit/index.js
@@ -23,5 +23,6 @@ Anyway, the developer can use a custom configuration if the \`karma.conf.js\` fi
         .option('[--nativescript <ios|android>]', 'Use nativescript.')
         .option('[--coverage]', 'Enable code coverage.')
         .option('[--ci]', 'Run in continuous integration mode.')
+        .option('[--context]', 'Use specified file as Karma custom context file for polyfill script.')
         .action(require('path').resolve(__dirname, './action.js'));
 };


### PR DESCRIPTION
Added option on unit command for specify a custom karma context file, opening scenarios such as adding script on context file for polyfills.

We could put a `test.html` file under unit tests folder in app projects. An example for `text.html` file can be:

```
<!DOCTYPE html>
<!--
This is the execution context.
Loaded within the iframe.
Reloaded before every execution run.
-->
<html>
<head>
  <title></title>
  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
</head>
<body>
  <!-- The scripts need to be in the body DOM element, as some test running frameworks need the body
       to have already been created so they can insert their magic into it. For example, if loaded
       before body, Angular Scenario test framework fails to find the body and crashes and burns in
       an epic manner. -->
    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=Promise,WeakMap,CustomEvent,Element.prototype.closest,Element.prototype.matches,fetch" charset="utf-8"></script>
  <script src="context.js"></script>
  <script type="text/javascript">
    // Configure our Karma and set up bindings
    %CLIENT_CONFIG%
    window.__karma__.setupContext(window);
    // All served files with the latest timestamps
    %MAPPINGS%
  </script>
  <!-- Dynamically replaced with <script> tags -->
  %SCRIPTS%
  <script type="text/javascript">
    window.__karma__.loaded();
  </script>
</body>
</html>

```