### PR TITLE
Run chrome without sandbox for CI

### DIFF
--- a/commands/unit/action.js
+++ b/commands/unit/action.js
@@ -108,7 +108,7 @@ function getConfig(app, options) {
                 usePhantomJS: false,
                 postDetection: (availableBrowser) => {
                     // we are replacing the detected `Chrome` with the `Chrome_CI` configuration.
-                    let ioChrome = availableBrowser.indexOf('Chrome');
+                    const ioChrome = availableBrowser.indexOf('Chrome');
                     if (ioChrome !== -1) {
                         availableBrowser.splice(ioChrome, 1, 'Chrome_CI');
                     }

--- a/commands/unit/action.js
+++ b/commands/unit/action.js
@@ -98,8 +98,22 @@ function getConfig(app, options) {
                 require('karma-opera-launcher'),
                 require('karma-detect-browsers')
             );
+            conf.customLaunchers = {
+                Chrome_CI: {
+                    base: 'Chrome',
+                    flags: ['--no-sandbox'],
+                },
+            };
             conf.detectBrowsers = {
                 usePhantomJS: false,
+                postDetection: (availableBrowser) => {
+                    // we are replacing the detected `Chrome` with the `Chrome_CI` configuration.
+                    let ioChrome = availableBrowser.indexOf('Chrome');
+                    if (ioChrome !== -1) {
+                        availableBrowser.splice(ioChrome, 1, 'Chrome_CI');
+                    }
+                    return availableBrowser;
+                },
             };
         }
 


### PR DESCRIPTION
fixes(#17)

At the moment, we have trouble running chrome in CI because the auto detection scripts does not run the browser with the `--no-sandbox` flag