### PR TITLE
Call shell scripts using array of arguments

### DIFF
--- a/commands/add/action.js
+++ b/commands/add/action.js
@@ -21,7 +21,7 @@ module.exports = (app, options) => {
         app.log(colors.yellow('🤷‍ specify the package to add.'));
     } else {
         // Add requested packages.
-        let request = options.dev ? manager.dev(...options.arguments) : manager.add(...options.arguments);
+        let request = options.dev ? manager.dev(paths.cwd, ...options.arguments) : manager.add(paths.cwd, ...options.arguments);
         return request
             .then((res) => {
                 app.log(colors.green('packages successfully added.'));

--- a/commands/e2e/action.js
+++ b/commands/e2e/action.js
@@ -181,7 +181,7 @@ module.exports = (app, options = {}) => {
             if (config.test_settings.default.launch_url) {
                 for (let k in config.test_settings) {
                     config.test_settings[k].desiredCapabilities = config.test_settings[k].desiredCapabilities || {};
-                    config.test_settings[k].desiredCapabilities['name'] = saucelabs.getTestName(config.test_settings.default.launch_url, 'E2E');
+                    config.test_settings[k].desiredCapabilities['name'] = saucelabs.getTestName(paths.cwd, config.test_settings.default.launch_url, 'E2E');
                 }
             }
             config.detailed_output = config.test_settings.default.detailed_output || !options.browsers || !options.browsers.includes(',');
@@ -193,7 +193,7 @@ module.exports = (app, options = {}) => {
                 promise = promise
                     .then(() => {
                         app.log(colors.cyan(`running ${env}`));
-                        return exec(`${NIGHTWATCH_BIN} --config ${configSource} --env ${env}`);
+                        return exec(NIGHTWATCH_BIN, ['--config', configSource, '--env', env]);
                     })
                     .catch(() => {
                         failed = true;

--- a/commands/install/action.js
+++ b/commands/install/action.js
@@ -15,7 +15,7 @@ module.exports = (app) => {
         return global.Promise.reject();
     }
     // Run `yarn install`.
-    return manager.update()
+    return manager.update(paths.cwd)
         .then((res) => {
             app.log(colors.green('dependencies successfully updated.'));
             return global.Promise.resolve(res);

--- a/commands/publish/action.js
+++ b/commands/publish/action.js
@@ -31,5 +31,5 @@ module.exports = (app, options) => {
     if (process.env.CI) {
         args.push('--yes');
     }
-    return exec(`${BIN} ${args.join(' ')}`);
+    return exec(BIN, args);
 };

--- a/commands/remove/action.js
+++ b/commands/remove/action.js
@@ -21,7 +21,7 @@ module.exports = (app, options = {}) => {
         app.log(colors.yellow('🤷‍ specify the package to remove.'));
     } else {
         // Remove requested packages.
-        return manager.remove(...options.arguments)
+        return manager.remove(paths.cwd, ...options.arguments)
             .then((res) => {
                 app.log(colors.green('packages successfully removed.'));
                 return global.Promise.resolve(res);

--- a/commands/run/action.js
+++ b/commands/run/action.js
@@ -14,5 +14,5 @@ module.exports = (app) => {
         app.log(colors.red('no project found.'));
         return global.Promise.reject();
     }
-    return manager.run(process.argv[3], process.argv.slice(4));
+    return manager.run(paths.cwd, process.argv[3], process.argv.slice(4));
 };

--- a/commands/setup/tasks/eslint.js
+++ b/commands/setup/tasks/eslint.js
@@ -36,7 +36,7 @@ module.exports = (app, options) => {
         configurator(eslintConfig, content, '# RNA');
 
         if (isNew) {
-            eslintPromise = manager.dev('eslint', 'eslint-plugin-mocha');
+            eslintPromise = manager.dev(paths.cwd, 'eslint', 'eslint-plugin-mocha');
             app.log(`${colors.green('.eslintrc.yml created.')} ${colors.grey(`(${eslintConfig})`)}`);
         } else {
             app.log(`${colors.green('.eslintrc.yml updated.')} ${colors.grey(`(${eslintConfig})`)}`);

--- a/commands/setup/tasks/git.js
+++ b/commands/setup/tasks/git.js
@@ -19,10 +19,10 @@ module.exports = (app, options) => {
         let gitPath = path.join(cwd, '.git');
 
         // Initialize repository if `.git` directory doesn't already exist.
-        let init = fs.existsSync(gitPath) ? global.Promise.resolve(true) : git.init();
+        let init = fs.existsSync(gitPath) ? global.Promise.resolve(true) : git.init(cwd);
 
         return init.then(() =>
-            git.getRemote()
+            git.getRemote(cwd)
                 .then((res) => {
                     if (res) {
                         if (!options.force) {
@@ -46,7 +46,7 @@ module.exports = (app, options) => {
                     return prompt([opts]).then((answers) => {
                         if (answers.repository) {
                             // Configure remote.
-                            return git.addRemote(answers.repository)
+                            return git.addRemote(cwd, answers.repository)
                                 .then(() => {
                                     app.log(`${colors.green('git project created.')} ${colors.grey(`(${cwd})`)}`);
                                     return global.Promise.resolve();
@@ -55,7 +55,7 @@ module.exports = (app, options) => {
 
                         // Remove remote.
                         // Is this needed? We don't end up here if a remote is configured already. ~~fquffio
-                        return git.removeRemote()
+                        return git.removeRemote(cwd)
                             .then(() => {
                                 app.log(`${colors.green('git project created without remote.')} ${colors.grey(`(${cwd})`)}`);
                             });

--- a/commands/setup/tasks/npm.js
+++ b/commands/setup/tasks/npm.js
@@ -30,7 +30,7 @@ module.exports = (app, options) => {
             }
         }
 
-        return git.getRemote()
+        return git.getRemote(cwd)
             .catch(() => global.Promise.resolve())
             .then((remote) => {
                 const formatQuestion = (msg) => `${colors.cyan('package')} > ${msg}:`;
@@ -42,10 +42,10 @@ module.exports = (app, options) => {
                         type: 'input',
                         name: 'name',
                         message: formatQuestion('name'),
-                        default: json.name || path.basename(cwd),
+                        default: (json.name || path.basename(cwd)).toLowerCase().replace(/\s+/g, '_'),
                         validate: (input) => input.length > 0
                             && input.length <= 214
-                            && !input.match(/A-Z/) // Is "C-A-Z-Z-O" not allowed here? ~~fquffio
+                            && !input.match(/A-Z/)
                             && !input.match(/^[._]/)
                             && !input.match(/^\s/)
                             && !input.match(/\s$/)

--- a/commands/start/action.js
+++ b/commands/start/action.js
@@ -14,5 +14,5 @@ module.exports = (app) => {
         app.log(colors.red('no project found.'));
         return global.Promise.reject();
     }
-    return manager.start();
+    return manager.start(paths.cwd);
 };

--- a/commands/unit/action.js
+++ b/commands/unit/action.js
@@ -127,7 +127,7 @@ function getConfig(app, options) {
                 recordScreenshots: true,
             };
             if (entry && entry.package) {
-                conf.sauceLabs.testName = saucelabs.getTestName(entry.package.name, 'Unit');
+                conf.sauceLabs.testName = saucelabs.getTestName(paths.cwd, entry.package.name, 'Unit');
             }
             let saucelabsBrowsers = saucelabs.launchers(options.targets ? browserslist.elaborate(options.targets) : browserslist.load(paths.cwd));
             conf.customLaunchers = saucelabsBrowsers;

--- a/commands/unit/lib/ns.js
+++ b/commands/unit/lib/ns.js
@@ -1,12 +1,13 @@
+const fs = require('fs-extra');
 const path = require('path');
 const exec = require('../../../lib/exec.js');
 const paths = require('../../../lib/paths.js');
 
 module.exports = function runNativeScriptTest(platform, file) {
     let p = path.join(paths.tmp, 'NSTest');
-    return exec(`tns create Test --path ${p}`)
-        .then(() => exec(`tns test init --path ${p}/Test --framework mocha`))
-        .then(() => exec(`cp ${file} ${p}/Test/app/tests`))
-        .then(() => exec(`tns test ${platform} --emulator --justlaunch --path ${p}/Test`));
+    return exec('tns', ['create', 'Test', '--path', p])
+        .then(() => exec('tns', ['test', 'init', '--path', `${p}/Test`, '--framework', 'mocha']))
+        .then(() => fs.copy(file, `${p}/Test/app/tests`))
+        .then(() => exec('tns', ['test', platform, '--emulator', '--justlaunch', '--path', `${p}/Test`]));
 
 };

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -7,14 +7,13 @@ const exec = require('child_process').spawn;
  * @param {boolean} result
  * @returns {Promise<string>}
  */
-module.exports = function execAsync(cmd, result = false) {
+module.exports = function execAsync(bin, args, result = false) {
     return new global.Promise((resolve, reject) => {
-        let splitted = cmd.split(' '); // git commit -m 'fix: this will fail the bad way' ~~fquffio
-        let opts = {};
+        const opts = {};
         if (!result) {
             opts.stdio = 'inherit';
         }
-        let p = exec(splitted.shift(), splitted, opts);
+        const p = exec(bin, args, opts);
 
         if (result) {
             // Standard output (1) and standard error (2) data requested.

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,75 +1,81 @@
 const exec = require('./exec.js');
-const paths = require('./paths.js');
 const execSync = require('child_process').execSync;
 
 module.exports = {
     /**
      * Initialize Git repository.
      *
+     * @param {String} path The git project path.
      * @returns {Promise}
      */
-    init() {
-        return exec(`git -C ${paths.cwd} init`);
+    init(path) {
+        return exec('git', ['-C', path, 'init']);
     },
 
     /**
      * Get URL of Git remote named "origin".
      *
+     * @param {String} path The git project path.
      * @returns {Promise<string>}
      */
-    getRemote() {
-        return exec(`git -C ${paths.cwd} config --get remote.origin.url`, true);
+    getRemote(path) {
+        return exec('git', ['-C', path, 'config', '--get', 'remote.origin.url'], true);
     },
 
     /**
      * Remove Git remote named "origin".
      *
+     * @param {String} path The git project path.
      * @returns {Promise<string>}
      */
-    removeRemote() {
-        return exec(`git -C ${paths.cwd} remote remove origin`, true)
+    removeRemote(path) {
+        return exec('git', ['-C', path, 'remote', 'remove', 'origin'], true)
             .catch(() => global.Promise.resolve());
     },
 
     /**
      * Add Git remote named "origin".
      *
-     * @param {string} url URL for remote (both fetch and push).
+     * @param {String} path The git project path.
+     * @param {String} url URL for remote (both fetch and push).
      * @returns {Promise<string>}
      */
-    addRemote(url) {
-        return this.getRemote()
-            .then(() => this.removeRemote())
+    addRemote(path, url) {
+        return this.getRemote(path)
+            .then(() => this.removeRemote(path))
             .catch(() => global.Promise.resolve())
             .then(() =>
-                exec(`git -C ${paths.cwd} remote add origin ${url}`, true)
+                exec('git', ['-C', path, 'remote', 'add', 'origin', url], true)
             );
     },
 
     /**
      * Get actual branch name.
      *
+     * @param {String} path The git project path.
      * @returns {String}
-     * */
-    getBranchName() {
-        return execSync('git rev-parse --abbrev-ref HEAD');
+     */
+    getBranchName(path) {
+        return execSync('git', ['-C', path, 'rev-parse', '--abbrev-ref', 'HEAD']);
     },
 
     /**
      * Get actual commit short code.
      *
+     * @param {String} path The git project path.
      * @returns {String}
-     * */
-    getShortCommitCode() {
-        return execSync('git rev-parse --short HEAD');
+     */
+    getShortCommitCode(path) {
+        return execSync('git', ['-C', path, 'rev-parse', '--short', 'HEAD']);
     },
 
     /**
      * Get actual commit message.
      *
+     * @param {String} path The git project path.
      * @returns {String}
-     * */
-    getCommitMessage() {
-        return execSync('git log -1 --pretty=%B');
+     */
+    getCommitMessage(path) {
+        return execSync('git', ['-C', path, 'log', '-1', '--pretty=%B']);
     },
 };

--- a/lib/package-manager.js
+++ b/lib/package-manager.js
@@ -4,45 +4,48 @@ const exec = require('./exec.js');
 
 const BIN = which.sync('yarn');
 
-let api = {
+module.exports = {
     /**
      * Run `yarn install` in project root.
      *
+     * @param {String} path The project root.
      * @returns {Promise}
      */
-    update() {
-        return exec(`${BIN} --cwd ${paths.cwd} install -W`);
+    update(path) {
+        return exec(BIN, ['--cwd', path, 'install', '-W']);
     },
 
     /**
      * Run `yarn add` in project root.
      *
-     * @param {string} ...packages Packages to be added.
+     * @param {String} path The project root.
+     * @param {String} ...packages Packages to be added.
      * @returns {Promise}
      */
-    add(...packages) {
-        return exec(`${BIN} --cwd ${paths.cwd} add ${packages.join(' ')} -W`);
+    add(path, ...packages) {
+        return exec(BIN, ['--cwd', path, 'add', ...packages, '-W']);
     },
 
     /**
      * Run `yarn add` in cli root.
      * Useful for plugins.
      *
-     * @param {string} ...packages Packages to be added.
+     * @param {String} ...packages Packages to be added.
      * @returns {Promise}
      */
     addToCli(...packages) {
-        return exec(`${BIN} --cwd ${paths.cli} add ${packages.join(' ')} -W`);
+        return exec(BIN, ['--cwd', paths.cli, 'add', ...packages, '-W']);
     },
 
     /**
      * Run `yarn add --dev` in project root.
      *
-     * @param {string} ...packages Development packages to be added.
+     * @param {String} path The project root.
+     * @param {String} ...packages Development packages to be added.
      * @returns {Promise}
      */
-    dev(...packages) {
-        return exec(`${BIN} --cwd ${paths.cwd} add ${packages.join(' ')} --dev -W`);
+    dev(path, ...packages) {
+        return exec(BIN, ['--cwd', path, 'add', ...packages, '--dev', '-W']);
     },
 
     /**
@@ -52,47 +55,49 @@ let api = {
      * @returns {Promise}
      */
     global(...packages) {
-        return exec(`${BIN} global add ${packages.join(' ')}`);
+        return exec(BIN, ['global', 'add', ...packages]);
     },
 
     /**
      * Run `yarn remove` in project root.
      *
-     * @param {string} ...packages Packages to be removed.
+     * @param {String} path The project root.
+     * @param {String} ...packages Packages to be removed.
      * @returns {Promise}
      */
-    remove(...packages) {
-        return exec(`${BIN} --cwd ${paths.cwd} remove ${packages.join(' ')} -W`);
+    remove(path, ...packages) {
+        return exec(BIN, ['--cwd', path, 'remove', ...packages, '-W']);
     },
 
     /**
      * Run `yarn start` in project root.
      *
+     * @param {String} path The project root.
      * @returns {Promise}
      */
-    start() {
-        return exec(`${BIN} --cwd ${paths.cwd} start`);
+    start(path) {
+        return exec(BIN, ['--cwd', path, 'start']);
     },
 
     /**
      * Run a generic project command in project root.
      *
-     * @param {string} cmd Project command to be run.
+     * @param {String} path The project root.
+     * @param {String} cmd Project command to be run.
      * @param {Array<string>} args Arguments to be passed to command.
      * @returns {Promise}
      */
-    run(cmd, args) {
-        return exec(`${BIN} --cwd ${paths.cwd} run ${cmd}${args.length ? ` ${args.join(' ')}` : ''}`);
+    run(path, cmd, args) {
+        return exec(BIN, ['--cwd', path, 'run', cmd, ...args]);
     },
 
     /**
      * Run `yarn init` in project root.
      *
+     * @param {String} path The project root.
      * @returns {Promise}
      */
-    init() {
-        return exec(`${BIN} --cwd ${paths.cwd} init`);
+    init(path) {
+        return exec(BIN, ['--cwd', path, 'init']);
     },
 };
-
-module.exports = api;

--- a/lib/saucelabs.js
+++ b/lib/saucelabs.js
@@ -1,7 +1,6 @@
 const request = require('sync-request');
 const git = require('./git.js');
 
-
 function browserslistConfig(entry, data) {
     let name = entry.split(' ')[0];
     let apiName;
@@ -116,11 +115,11 @@ module.exports = {
         return res;
     },
 
-    getTestName(project, testType) {
+    getTestName(cwd, project, testType) {
         let name = `${testType} tests for ${project}`;
-        const branchName = git.getBranchName();
-        const commit = git.getShortCommitCode();
-        const commitMessage = git.getCommitMessage();
+        const branchName = git.getBranchName(cwd);
+        const commit = git.getShortCommitCode(cwd);
+        const commitMessage = git.getCommitMessage(cwd);
 
         if (branchName) {
             name = `${name} in branch: ${branchName}`;


### PR DESCRIPTION
Fixes(#14)

We have found out that the `exec` method was buggy (arguments were splitted by white spaces).
This PR converts all single string commands into array of arguments, in order to avoid splitting.