### PR TITLE
Match paths using regexes to make `yarn link` work

### DIFF
--- a/commands/build/bundlers/rollup.js
+++ b/commands/build/bundlers/rollup.js
@@ -33,6 +33,7 @@ function getBabelConfig(options) {
             loose: true,
         }],
         [require('../plugins/babel-plugin-resolve/babel-plugin-resolve.js'), {
+            modulesPaths: [path.join(paths.cwd, 'node_modules')],
             exclude: ['\0rollupPluginBabelHelpers', 'rollupCommonGlobal'],
         }],
         [require('../plugins/babel-plugin-external-jsx/babel-plugin-external-jsx.js'), {

--- a/commands/build/bundlers/rollup.js
+++ b/commands/build/bundlers/rollup.js
@@ -13,7 +13,7 @@ const sass = require('rollup-plugin-sass-modules');
 const uglify = require('rollup-plugin-uglify');
 const json = require('rollup-plugin-json');
 const url = require('rollup-plugin-url');
-const string = require('rollup-plugin-string');
+const string = require('../plugins/rollup-plugin-string/rollup-plugin-string');
 const optimize = require('rollup-plugin-optimize-js');
 
 const postcss = require('postcss');
@@ -33,7 +33,7 @@ function getBabelConfig(options) {
             loose: true,
         }],
         [require('../plugins/babel-plugin-resolve/babel-plugin-resolve.js'), {
-            exclude: ['rollupPluginBabelHelpers', 'rollupCommonGlobal'],
+            exclude: ['\0rollupPluginBabelHelpers', 'rollupCommonGlobal'],
         }],
         [require('../plugins/babel-plugin-external-jsx/babel-plugin-external-jsx.js'), {
             // Required to be specified
@@ -55,7 +55,7 @@ function getBabelConfig(options) {
     }
 
     return {
-        include: '**/*.{mjs,js,jsx}',
+        include: /\.(mjs|js|jsx)$/,
         babelrc: false,
         compact: false,
         presets: [
@@ -108,14 +108,14 @@ function getConfig(app, bundler, options) {
                 json(),
                 string({
                     include: [
-                        '**/*.{html,txt,svg,md}',
+                        /\.(html|txt|svg|md)$/,
                     ],
                 }),
                 url({
                     limit: 10 * 1000 * 1024,
                     exclude: [],
                     include: [
-                        '**/*.{woff,ttf,eot,gif,png,jpg}',
+                        /\.(woff|ttf|eot|gif|png|jpg)$/,
                     ],
                 }),
                 sass({
@@ -127,7 +127,7 @@ function getConfig(app, bundler, options) {
                         ).process(css).then(result => result.css),
                     exclude: [],
                     include: [
-                        '**/*.{css,scss,sass}',
+                        /\.(css|scss|sass)$/,
                     ],
                     options: {
                         outFile: options['external-css'] && path.join(

--- a/commands/build/plugins/babel-plugin-resolve/babel-plugin-resolve.js
+++ b/commands/build/plugins/babel-plugin-resolve/babel-plugin-resolve.js
@@ -72,6 +72,7 @@ function importResolve({ types }) {
         const filename = importDecl.hub.file.opts.filename;
         const dirname = path.dirname(filename);
         const opts = state.opts;
+        const nodeModules = (opts.modulesPaths || []).concat([dirname]);
         const include = opts.include || [];
         const exclude = opts.exclude || [];
         const source = importDecl.get('source');
@@ -90,7 +91,7 @@ function importResolve({ types }) {
         }
         try {
             if (RELATIVE_PATH.test(value)) {
-                value = require.resolve(value, { paths: [dirname] });
+                value = require.resolve(value, { paths: nodeModules });
             } else {
                 if (isCore(value)) {
                     // core nodejs modules
@@ -105,10 +106,10 @@ function importResolve({ types }) {
                 }
                 if (parts.length) {
                     // file request
-                    value = require.resolve(value, { paths: [dirname] });
+                    value = require.resolve(value, { paths: nodeModules });
                 } else {
                     // module request
-                    let pkgName = require.resolve(`${modName}/package.json`, { paths: [dirname] });
+                    let pkgName = require.resolve(`${modName}/package.json`, { paths: nodeModules });
                     if (!pkgName) {
                         return;
                     }

--- a/commands/build/plugins/rollup-plugin-string/rollup-plugin-string.js
+++ b/commands/build/plugins/rollup-plugin-string/rollup-plugin-string.js
@@ -1,0 +1,24 @@
+const { createFilter } = require('rollup-pluginutils');
+
+module.exports = function string(opts = {}) {
+    if (!opts.include) {
+        throw Error('include option should be specified');
+    }
+
+    const filter = createFilter(opts.include, opts.exclude);
+
+    return {
+        name: 'string',
+
+        transform(code, id) {
+            if (filter(id)) {
+                return {
+                    code: `export default ${JSON.stringify(code)}; `,
+                    map: {
+                        mappings: '',
+                    },
+                };
+            }
+        },
+    };
+};

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "rollup-plugin-json": "^2.3.0",
     "rollup-plugin-optimize-js": "^0.0.4",
     "rollup-plugin-sass-modules": "^1.4.0",
-    "rollup-plugin-string": "^2.0.2",
     "rollup-plugin-uglify": "^3.0.0",
     "rollup-plugin-url": "^1.3.0",
     "sass": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3564,10 +3564,6 @@ estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
-estree-walker@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
-
 estree-walker@^0.3.0:
   version "0.3.1"
   resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
@@ -7768,12 +7764,6 @@ rollup-plugin-sass-modules@^1.4.0:
     rollup-pluginutils "^2.0.1"
     sass "^1.3.2"
 
-rollup-plugin-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/rollup-plugin-string/-/rollup-plugin-string-2.0.2.tgz#f5323a22cfd738b450cbea62ab6593705eac744b"
-  dependencies:
-    rollup-pluginutils "^1.5.0"
-
 rollup-plugin-uglify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/rollup-plugin-uglify/-/rollup-plugin-uglify-3.0.0.tgz#a34eca24617709c6bf1778e9653baafa06099b86"
@@ -7786,13 +7776,6 @@ rollup-plugin-url@^1.3.0:
   dependencies:
     mime "^2.3.1"
     rollup-pluginutils "^2.0.1"
-
-rollup-pluginutils@^1.5.0:
-  version "1.5.2"
-  resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
-  dependencies:
-    estree-walker "^0.2.1"
-    minimatch "^3.0.2"
 
 rollup-pluginutils@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This PR changes the way paths are matched by Rollup from glob-style to regex-based. The `rollup-plugin-string` has been imported to make use of latest version of Rollup utils.

This PR makes it possible to use `yarn link` for local development.

Credits: @edoardocavazza 