### PR TITLE
Soft-fail on connection error when checking for updates

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -348,28 +348,31 @@ class CLI {
         }
         const https = require('https');
         return new global.Promise((resolve, reject) => {
-            https.get('https://registry.npmjs.org/@chialab%2Frna-cli', (response) => {
-                if (response) {
-                    let str = '';
-                    response.on('data', (chunk) => {
-                        str += chunk;
-                    });
-                    response.on('end', () => {
-                        try {
-                            let remoteJson = JSON.parse(str);
-                            let version = remoteJson['dist-tags'] && remoteJson['dist-tags']['latest'];
-                            if (version && this.v !== version) {
-                                resolve(version);
+            https
+                .get('https://registry.npmjs.org/@chialab%2Frna-cli', (response) => {
+                    if (response) {
+                        let str = '';
+                        response.on('data', (chunk) => {
+                            str += chunk;
+                        });
+                        response.on('end', () => {
+                            try {
+                                let remoteJson = JSON.parse(str);
+                                let version = remoteJson['dist-tags'] && remoteJson['dist-tags']['latest'];
+                                if (version && this.v !== version) {
+                                    resolve(version);
+                                }
+                                reject();
+                            } catch (err) {
+                                reject(err);
                             }
-                            reject();
-                        } catch (err) {
-                            reject(err);
-                        }
-                    });
-                } else {
-                    reject();
-                }
-            }).end();
+                        });
+                    } else {
+                        reject();
+                    }
+                })
+                .on('error', (err) => reject(err))
+                .end();
         });
     }
 }


### PR DESCRIPTION
This PR fixes a blocking error that caused the CLI to be unusable if network is disconnected, or `registry.npmjs.org` is somehow unreachable.