### PR TITLE
Build docker images on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,34 +8,39 @@ stages:
 jobs:
   include:
     - stage: build
-      if: 'type = "push" AND branch = "master"'
+      if: 'type = "push" AND (branch = "master" OR tag =~ /^v?([0-9.]+(-.+)?)$/)'
       before_install:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       script:
-        - 'docker build -t "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" .'
+        - 'docker build -t artifact .'
       after_success:
-        - 'docker push "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}"'
+        - |
+          if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ]; then
+            echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}\033[34m image\033[0m..."
+            docker tag artifact "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}"
+            docker push "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}"'
+          fi
         - |
           if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+(-.+)?)$ ]]; then
             echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}\033[34m image\033[0m..."
-            docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}"
+            docker tag artifact "${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}"
             docker push "${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}"
 
             if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+)$ ]]; then
               echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:latest\033[34m image\033[0m..."
-              docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:latest"
+              docker tag artifact "${TRAVIS_REPO_SLUG}:latest"
               docker push "${TRAVIS_REPO_SLUG}:latest"
             elif [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-rc(\..+)?)$ ]]; then
               echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:rc\033[34m image\033[0m..."
-              docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:rc"
+              docker tag artifact "${TRAVIS_REPO_SLUG}:rc"
               docker push "${TRAVIS_REPO_SLUG}:rc"
             elif [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-beta(\..+)?)$ ]]; then
               echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:beta\033[34m image\033[0m..."
-              docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:beta"
+              docker tag artifact "${TRAVIS_REPO_SLUG}:beta"
               docker push "${TRAVIS_REPO_SLUG}:beta"
             elif [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-alpha(\..+)?)$ ]]; then
               echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:alpha\033[34m image\033[0m..."
-              docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:alpha"
+              docker tag artifact "${TRAVIS_REPO_SLUG}:alpha"
               docker push "${TRAVIS_REPO_SLUG}:alpha"
             fi
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+sudo: true
+dist: trusty
+language: minimal
+
+stages:
+  - name: build
+    # if: 'fork = false'
+jobs:
+  include:
+    - stage: build
+      if: 'type = "push" AND branch = "master"'
+      before_install:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      script:
+        - 'docker build -t "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" .'
+      after_success:
+        - 'docker push "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}"'
+        - |
+          if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+(-.+)?)$ ]]; then
+            echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}\033[34m image\033[0m..."
+            docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}"
+            docker push "${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}"
+
+            if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+)$ ]]; then
+              echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:latest\033[34m image\033[0m..."
+              docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:latest"
+              docker push "${TRAVIS_REPO_SLUG}:latest"
+            elif [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-rc(\..+)?)$ ]]; then
+              echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:rc\033[34m image\033[0m..."
+              docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:rc"
+              docker push "${TRAVIS_REPO_SLUG}:rc"
+            elif [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-beta(\..+)?)$ ]]; then
+              echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:beta\033[34m image\033[0m..."
+              docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:beta"
+              docker push "${TRAVIS_REPO_SLUG}:beta"
+            elif [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-alpha(\..+)?)$ ]]; then
+              echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:alpha\033[34m image\033[0m..."
+              docker tag "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH}" "${TRAVIS_REPO_SLUG}:alpha"
+              docker push "${TRAVIS_REPO_SLUG}:alpha"
+            fi
+          fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ language: minimal
 
 stages:
   - name: build
-    # if: 'fork = false'
+    if: 'fork = false'
+
 jobs:
   include:
     # Build branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,40 +7,52 @@ stages:
     # if: 'fork = false'
 jobs:
   include:
+    # Build branches:
     - stage: build
-      if: 'type = "push" AND (branch = "master" OR tag =~ /^v?([0-9.]+(-.+)?)$/)'
+      if: 'type IN ("push", "cron") AND branch = "master"'
       before_install:
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       script:
         - 'docker build -t artifact .'
       after_success:
-        - |
-          if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ]; then
-            echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}\033[34m image\033[0m..."
-            docker tag artifact "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}"
-            docker push "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}"
-          fi
-        - |
-          if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+(-.+)?)$ ]]; then
-            echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}\033[34m image\033[0m..."
-            docker tag artifact "${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}"
-            docker push "${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}"
+        - | # Branch
+          echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}\033[34m image\033[0m..."
+          docker tag artifact "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}"
+          docker push "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}"
 
-            if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+)$ ]]; then
-              echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:latest\033[34m image\033[0m..."
-              docker tag artifact "${TRAVIS_REPO_SLUG}:latest"
-              docker push "${TRAVIS_REPO_SLUG}:latest"
-            elif [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-rc(\..+)?)$ ]]; then
-              echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:rc\033[34m image\033[0m..."
-              docker tag artifact "${TRAVIS_REPO_SLUG}:rc"
-              docker push "${TRAVIS_REPO_SLUG}:rc"
-            elif [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-beta(\..+)?)$ ]]; then
-              echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:beta\033[34m image\033[0m..."
-              docker tag artifact "${TRAVIS_REPO_SLUG}:beta"
-              docker push "${TRAVIS_REPO_SLUG}:beta"
-            elif [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-alpha(\..+)?)$ ]]; then
-              echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:alpha\033[34m image\033[0m..."
-              docker tag artifact "${TRAVIS_REPO_SLUG}:alpha"
-              docker push "${TRAVIS_REPO_SLUG}:alpha"
-            fi
+    # Build tags:
+    - stage: build
+      if: 'type = "push" AND tag =~ /^v?([0-9.]+(-.+)?)$/'
+      before_install:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      script:
+        - 'docker build -t artifact .'
+      after_success:
+        - | # Tag
+          echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}\033[34m image\033[0m..."
+          docker tag artifact "${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}"
+          docker push "${TRAVIS_REPO_SLUG}:${TRAVIS_TAG:1}"
+        - | # Latest
+          if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+)$ ]]; then
+            echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:latest\033[34m image\033[0m..."
+            docker tag artifact "${TRAVIS_REPO_SLUG}:latest"
+            docker push "${TRAVIS_REPO_SLUG}:latest"
+          fi
+        - | # RC
+          if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-rc(\..+)?)$ ]]; then
+            echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:rc\033[34m image\033[0m..."
+            docker tag artifact "${TRAVIS_REPO_SLUG}:rc"
+            docker push "${TRAVIS_REPO_SLUG}:rc"
+          fi
+        - | # Beta
+          if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-beta(\..+)?)$ ]]; then
+            echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:beta\033[34m image\033[0m..."
+            docker tag artifact "${TRAVIS_REPO_SLUG}:beta"
+            docker push "${TRAVIS_REPO_SLUG}:beta"
+          fi
+        - | # Alpha
+          if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+-alpha(\..+)?)$ ]]; then
+            echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:alpha\033[34m image\033[0m..."
+            docker tag artifact "${TRAVIS_REPO_SLUG}:alpha"
+            docker push "${TRAVIS_REPO_SLUG}:alpha"
           fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
           if [ "$TRAVIS_BRANCH" != "$TRAVIS_TAG" ]; then
             echo -e "\033[34mPushing \033[33;1m${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}\033[34m image\033[0m..."
             docker tag artifact "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}"
-            docker push "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}"'
+            docker push "${TRAVIS_REPO_SLUG}:dev-${TRAVIS_BRANCH/\//-}"
           fi
         - |
           if [[ "$TRAVIS_TAG" =~ ^v?([0-9.]+(-.+)?)$ ]]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM node
 
 COPY . /opt/rna
 RUN git -C /opt/rna clean -Xdf \
-    && yarn global add /opt/rna
+    && yarn global add /opt/rna \
+    && yarn cache clean


### PR DESCRIPTION
This PR sets up the build of Docker images on Travis CI, replacing Docker Cloud's automated builds, for Travis CI builds are more flexible, and generally faster and more reliable, than the Docker Cloud builds.

A simple `.travis.yml` file has been added.

As a bonus track, a small change has been made to the `Dockerfile`: Yarn global cache is cleared after RNA is installed. This cuts down the image size from 408mb to 325mb. 📦 Data transfer bills for continuous integration servers that use this base image will be happy.