### PR TITLE
Handle unresolved imports

### DIFF
--- a/lib/Bundlers/Rollup.js
+++ b/lib/Bundlers/Rollup.js
@@ -279,7 +279,7 @@ class Rollup extends EventEmitter {
                 const missingDeps = module.dependencies.filter((id) => !dependencies.some((dep) => dep === id) && !devDependencies.some((devDep) => devDep === id));
                 if (missingDeps.length) {
                     missingDeps.forEach((dep) => {
-                        const warning = `Missing "${dep}" in package.json for ${module.id}\n`;
+                        const warning = `Dependency "${dep}" is not listed in ${packageJsonPath}`;
                         this.emit('warning', warning);
                     });
                 }

--- a/lib/Bundlers/Rollup.js
+++ b/lib/Bundlers/Rollup.js
@@ -246,25 +246,25 @@ class Rollup extends EventEmitter {
 
     /**
      * Check if modules from the bundle have some import that is missing in the closest `package.json`.
-     *
      * @fires warning Fired when missing dependencies are found.
      */
     checkDependencies() {
-        // Filter modules to process excluding not '.js' files and files from 'node_modules'.
+        // This RegExp matches strings starting with: '/', './', '../', '\u0000rollupPluginBabelHelpers' (the slash is relative to the OS).
+        const pathRegex = new RegExp(`^(\\.{1,2}\\${path.sep}|\\x00rollupPluginBabelHelpers)`);
         const modulesToCheck = this.result.modules
             .map((mod) => ({
                 id: mod.id,
+                // Filter dependencies by these criteria: not matching the RegExp above, not absolute path, not an existing file.
                 dependencies: Object.keys(mod.resolvedIds).filter((dep) =>
-                    !dep.includes('rollupPluginBabelHelpers') &&
-                    !dep.startsWith('./') &&
-                    !dep.startsWith('../') &&
-                    !dep.startsWith('/') &&
+                    !pathRegex.test(dep) &&
                     !path.isAbsolute(dep) &&
                     !fs.existsSync(dep)
                 ),
             }))
+            // Filter modules to process excluding not '.js' files and files from 'node_modules'.
             .filter((mod) => !mod.id.includes('/node_modules/') && mod.id.endsWith('.js'));
 
+        let warnings = [];
         modulesToCheck.forEach((module) => {
             let parent = path.dirname(module.id);
             // Search for closest package.json. Stop digging at `process.cwd`.
@@ -280,13 +280,15 @@ class Rollup extends EventEmitter {
                 if (missingDeps.length) {
                     missingDeps.forEach((dep) => {
                         const warning = `Dependency "${dep}" is not listed in ${packageJsonPath}`;
-                        this.emit('warning', warning);
+                        warnings.push(warning);
                     });
                 }
             } catch (error) {
                 //
             }
         });
+        // Emit only for distinct warnings.
+        [...new Set(warnings)].forEach((warn) => this.emit('warning', warn));
     }
 
     async build() {

--- a/lib/Bundlers/Rollup.js
+++ b/lib/Bundlers/Rollup.js
@@ -252,6 +252,8 @@ class Rollup extends EventEmitter {
         // This RegExp matches strings starting with: '/', './', '../', '\u0000rollup' (the slash is relative to the OS).
         const pathRegex = new RegExp(`^(\\.{1,2}\\${path.sep}|\\x00rollup)`);
         const modulesToCheck = this.result.modules
+            // Filter modules to process excluding not '.js' files and files from 'node_modules'.
+            .filter((mod) => !mod.id.includes('/node_modules/') && mod.id.endsWith('.js'))
             .map((mod) => ({
                 id: mod.id,
                 // Filter dependencies by these criteria: not matching the RegExp above, not absolute path, not an existing file.
@@ -260,13 +262,11 @@ class Rollup extends EventEmitter {
                     !path.isAbsolute(dep) &&
                     !fs.existsSync(dep)
                 ),
-            }))
-            // Filter modules to process excluding not '.js' files and files from 'node_modules'.
-            .filter((mod) => !mod.id.includes('/node_modules/') && mod.id.endsWith('.js'));
+            }));
 
         let warnings = [];
-        modulesToCheck.forEach((module) => {
-            let parent = path.dirname(module.id);
+        modulesToCheck.forEach((mod) => {
+            let parent = path.dirname(mod.id);
             // Search for closest package.json. Stop digging at `process.cwd`.
             while (!fs.existsSync(path.resolve(parent, 'package.json')) && parent !== process.cwd()) {
                 parent = path.dirname(parent);
@@ -276,18 +276,20 @@ class Rollup extends EventEmitter {
                 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
                 const dependencies = Object.keys(packageJson.dependencies || {});
                 const peerDependencies = Object.keys(packageJson.peerDependencies || {});
-                const missingDeps = module.dependencies.filter((id) =>
+                const missingDeps = mod.dependencies.filter((id) =>
                     !dependencies.some((dep) => dep === id) &&
                     !peerDependencies.some((peerDep) => peerDep === id));
-                if (missingDeps.length) {
-                    missingDeps.forEach((dep) => {
-                        const warning = `Dependency "${dep}" is not listed in ${packageJsonPath}`;
-                        // Avoid duplicate warnings.
-                        if (!~warnings.findIndex(warning)) {
-                            warnings.push(warning);
-                        }
-                    });
+                if (!missingDeps.length) {
+                    return;
                 }
+                missingDeps.forEach((dep) => {
+                    let warning = `dependency "${dep}" is not listed in ${packageJsonPath}`;
+                    // Avoid duplicate warnings.
+                    if (warnings.includes(warning)) {
+                        return;
+                    }
+                    warnings.push(warning);
+                });
             } catch (error) {
                 //
             }

--- a/lib/Bundlers/Rollup.js
+++ b/lib/Bundlers/Rollup.js
@@ -244,16 +244,65 @@ class Rollup extends EventEmitter {
         this.options = Object.assign({}, options);
     }
 
+    /**
+     * Check if modules from the bundle have some import that is missing in the closest `package.json`.
+     *
+     * @fires warning Fired when missing dependencies are found.
+     */
+    checkDependencies() {
+        // Filter modules to process excluding not '.js' files and files from 'node_modules'.
+        const modulesToCheck = this.result.modules
+            .map((mod) => ({
+                id: mod.id,
+                dependencies: Object.keys(mod.resolvedIds).filter((dep) =>
+                    !dep.includes('rollupPluginBabelHelpers') &&
+                    !dep.startsWith('./') &&
+                    !dep.startsWith('../') &&
+                    !dep.startsWith('/') &&
+                    !path.isAbsolute(dep) &&
+                    !fs.existsSync(dep)
+                ),
+            }))
+            .filter((mod) => !mod.id.includes('/node_modules/') && mod.id.endsWith('.js'));
+
+        modulesToCheck.forEach((module) => {
+            let parent = path.dirname(module.id);
+            // Search for closest package.json. Stop digging at `process.cwd`.
+            while (!fs.existsSync(path.resolve(parent, 'package.json')) && parent !== process.cwd()) {
+                parent = path.dirname(parent);
+            }
+            try {
+                const packageJsonPath = path.resolve(parent, 'package.json');
+                const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+                const dependencies = Object.keys(packageJson.dependencies || {});
+                const devDependencies = Object.keys(packageJson.devDependencies || {});
+                const missingDeps = module.dependencies.filter((id) => !dependencies.some((dep) => dep === id) && !devDependencies.some((devDep) => devDep === id));
+                if (missingDeps.length) {
+                    missingDeps.forEach((dep) => {
+                        const warning = `Missing "${dep}" in package.json for ${module.id}\n`;
+                        this.emit('warning', warning);
+                    });
+                }
+            } catch (error) {
+                //
+            }
+        });
+    }
+
     async build() {
         let config = Object.assign({
             cache: Rollup.cache.toConfig(),
             onwarn: (warning) => {
+                if (warning.code === 'UNRESOLVED_IMPORT') {
+                    throw warning;
+                }
                 this.emit('warning', warning);
             },
         }, this.options);
         this.result = await rollup(config);
         Rollup.cache.addBundleToCache(this.result);
         delete this.result.cache;
+        this.checkDependencies();
         return this.result;
     }
 

--- a/lib/Bundlers/Rollup.js
+++ b/lib/Bundlers/Rollup.js
@@ -282,15 +282,18 @@ class Rollup extends EventEmitter {
                 if (missingDeps.length) {
                     missingDeps.forEach((dep) => {
                         const warning = `Dependency "${dep}" is not listed in ${packageJsonPath}`;
-                        warnings.push(warning);
+                        // Avoid duplicate warnings.
+                        if (!~warnings.findIndex(warning)) {
+                            warnings.push(warning);
+                        }
                     });
                 }
             } catch (error) {
                 //
             }
         });
-        // Emit only for distinct warnings.
-        [...new Set(warnings)].forEach((warn) => this.emit('warning', warn));
+
+        warnings.forEach((warn) => this.emit('warning', warn));
     }
 
     async build() {

--- a/lib/Bundlers/Rollup.js
+++ b/lib/Bundlers/Rollup.js
@@ -249,8 +249,8 @@ class Rollup extends EventEmitter {
      * @fires warning Fired when missing dependencies are found.
      */
     checkDependencies() {
-        // This RegExp matches strings starting with: '/', './', '../', '\u0000rollupPluginBabelHelpers' (the slash is relative to the OS).
-        const pathRegex = new RegExp(`^(\\.{1,2}\\${path.sep}|\\x00rollupPluginBabelHelpers)`);
+        // This RegExp matches strings starting with: '/', './', '../', '\u0000rollup' (the slash is relative to the OS).
+        const pathRegex = new RegExp(`^(\\.{1,2}\\${path.sep}|\\x00rollup)`);
         const modulesToCheck = this.result.modules
             .map((mod) => ({
                 id: mod.id,
@@ -275,8 +275,10 @@ class Rollup extends EventEmitter {
                 const packageJsonPath = path.resolve(parent, 'package.json');
                 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
                 const dependencies = Object.keys(packageJson.dependencies || {});
-                const devDependencies = Object.keys(packageJson.devDependencies || {});
-                const missingDeps = module.dependencies.filter((id) => !dependencies.some((dep) => dep === id) && !devDependencies.some((devDep) => devDep === id));
+                const peerDependencies = Object.keys(packageJson.peerDependencies || {});
+                const missingDeps = module.dependencies.filter((id) =>
+                    !dependencies.some((dep) => dep === id) &&
+                    !peerDependencies.some((peerDep) => peerDep === id));
                 if (missingDeps.length) {
                     missingDeps.forEach((dep) => {
                         const warning = `Dependency "${dep}" is not listed in ${packageJsonPath}`;


### PR DESCRIPTION
This MR adds a check for missing listed dependencies. Modules imported but not listed in its relative `package.json`, will show a warning in the terminal during the build process.