### PR TITLE
Copy css assets

### DIFF
--- a/commands/build/README.md
+++ b/commands/build/README.md
@@ -9,12 +9,13 @@ It supports:
 
 ### Options
 
-* `--output` Specify the output file or directory for the build.
+* `--output <file>` Specify the output file or directory for the build.
 * `--targets` Set specific targets for the build using a [Browserslist](https://github.com/browserslist/browserslist). This query is used by Babel and PostCSS to transpile JavaScript and CSS files in order to be compatible with the specified browsers. Use `--no-targets` to prevent code transpiling.
 * `--name` For JavaScript builds, you can specify the name of the global variable to use for the bundle.
 * `--format` Specify the format of the JavaScript bundle. Available formats are `es`, `umd` (default), `iife` and `cjs`.
 * `--production` Minify the output of the JavaScript and CSS bundles.
 * `--declaration` Enable TypeScript `.d.ts` generation.
+* `--assets <directory>` The build assets directory.
 * `--watch` Watch source files and rebuild the bundle every time a file change occurred.
 * `--no-map` Disable source maps creation. It speeds up the build but you will lose code mapping in the debugger.
 * `--no-lint` Disable linting of the source files.

--- a/commands/build/index.js
+++ b/commands/build/index.js
@@ -11,12 +11,13 @@ module.exports = (program) => {
         .readme(`${__dirname}/README.md`)
         .option('<file>', 'The file to build.')
         .option('<package1> <package2> <package3>', 'The packages to build.')
-        .option('--output', 'The destination file.')
+        .option('--output <file>', 'The destination file.')
         .option('[--targets]', 'A supported browserslist query. Use --no-targets to transpile only non-standard features.')
         .option('[--name]', 'The bundle name.')
         .option('[--format]', 'The bundle format (es, umd, iife, cjs).')
         .option('[--production]', 'Minify bundle.')
         .option('[--declaration]', 'Generate typescript declarations.')
+        .option('[--assets] <directory>', 'The build assets directory.')
         .option('[--watch]', 'Watch sources and rebuild on files changes.')
         .option('[--no-map]', 'Do not produce source map.')
         .option('[--no-lint]', 'Do not lint files before bundle.')
@@ -102,6 +103,7 @@ module.exports = (program) => {
                             production: options.production,
                             map: options.map,
                             lint: options.lint,
+                            assets: options.assets,
                         });
                         // collect the generated Bundle.
                         bundles.push(manifest);
@@ -119,6 +121,7 @@ module.exports = (program) => {
                             production: options.production,
                             map: options.map,
                             lint: options.lint,
+                            assets: options.assets,
                         });
                         // collect the generated Bundle.
                         bundles.push(manifest);
@@ -150,6 +153,7 @@ module.exports = (program) => {
                         production: options.production,
                         map: options.map,
                         lint: options.lint,
+                        assets: options.assets,
                     });
                     // collect the generated Bundle
                     bundles.push(manifest);
@@ -165,6 +169,7 @@ module.exports = (program) => {
                         production: options.production,
                         map: options.map,
                         lint: options.lint,
+                        assets: options.assets,
                     });
                     // collect the generated Bundle
                     bundles.push(manifest);
@@ -260,6 +265,7 @@ async function rollup(app, project, options, bundle = {}) {
                 map: options.map,
                 lint: options.lint,
                 targets: options.targets,
+                assets: options.assets,
             });
         }
 
@@ -338,6 +344,7 @@ async function postcss(app, project, options, bundle = {}) {
                 map: options.map,
                 lint: options.lint,
                 targets: options.targets,
+                assets: options.assets,
             });
         }
         app.logger.play('postcss...', input.localPath);

--- a/lib/Bundlers/PostCSS.js
+++ b/lib/Bundlers/PostCSS.js
@@ -34,7 +34,7 @@ class PostCSS {
             copy({
                 basePath: [project.path],
                 dest: path.dirname(options.output),
-                template: path.join(options.assetsDir || 'assets', '[name].[hash].[ext]'),
+                template: path.join(options.assets || 'assets', '[name].[hash].[ext]'),
             }),
             autoprefixer({
                 browsers: options.targets,

--- a/lib/Bundlers/PostCSS.js
+++ b/lib/Bundlers/PostCSS.js
@@ -6,6 +6,7 @@ const unset = require('postcss-all-unset');
 const cssnano = require('cssnano');
 const focusVisible = require('postcss-focus-visible');
 const focusWithin = require('postcss-focus-within');
+const copy = require('postcss-copy');
 const StyleLint = require('../Linters/Stylelint');
 const stylelintPlugin = require('./plugins/postcss-stylelint-plugin/postcss-stylelint-plugin.js');
 const sass = require('./plugins/postcss-dart-sass/postcss-dart-sass.js');
@@ -29,6 +30,11 @@ class PostCSS {
                 sourceMapContents: true,
                 sourceMapEmbed: false,
                 sourceMap: !options.map,
+            }),
+            copy({
+                basePath: [project.path],
+                dest: path.dirname(options.output),
+                template: path.join(options.assetFileNames || 'assets', '[name].[ext]'),
             }),
             autoprefixer({
                 browsers: options.targets,

--- a/lib/Bundlers/PostCSS.js
+++ b/lib/Bundlers/PostCSS.js
@@ -34,7 +34,7 @@ class PostCSS {
             copy({
                 basePath: [project.path],
                 dest: path.dirname(options.output),
-                template: path.join(options.assetFileNames || 'assets', '[name].[ext]'),
+                template: path.join(options.assetsDir || 'assets', '[name].[hash].[ext]'),
             }),
             autoprefixer({
                 browsers: options.targets,

--- a/lib/Bundlers/Rollup.js
+++ b/lib/Bundlers/Rollup.js
@@ -77,7 +77,7 @@ function getConfig(app, project, options) {
             sourcemap: (typeof options.map === 'string') ? options.map : (options.map !== false),
             strict: false,
             indent: false,
-            assetFileNames: path.join(options.assetFileNames || 'assets', '[name][extname]'),
+            assetFileNames: path.join(options.assetsDir || 'assets', '[name].[hash].[ext]'),
         },
         plugins: [
             options.lint !== false ? eslint({

--- a/lib/Bundlers/Rollup.js
+++ b/lib/Bundlers/Rollup.js
@@ -77,7 +77,7 @@ function getConfig(app, project, options) {
             sourcemap: (typeof options.map === 'string') ? options.map : (options.map !== false),
             strict: false,
             indent: false,
-            assetFileNames: path.join(options.assetsDir || 'assets', '[name].[hash].[ext]'),
+            assetFileNames: path.join(options.assets || 'assets', '[name].[hash].[ext]'),
         },
         plugins: [
             options.lint !== false ? eslint({

--- a/lib/Bundlers/Rollup.js
+++ b/lib/Bundlers/Rollup.js
@@ -77,7 +77,7 @@ function getConfig(app, project, options) {
             sourcemap: (typeof options.map === 'string') ? options.map : (options.map !== false),
             strict: false,
             indent: false,
-            assetFileNames: options.assetFileNames || 'assets/[name][extname]',
+            assetFileNames: path.join(options.assetFileNames || 'assets', '[name][extname]'),
         },
         plugins: [
             options.lint !== false ? eslint({

--- a/lib/Bundlers/plugins/postcss-dart-sass/postcss-dart-sass.js
+++ b/lib/Bundlers/plugins/postcss-dart-sass/postcss-dart-sass.js
@@ -32,13 +32,38 @@ module.exports = postcss.plugin('postcss-dart-sass-plugin', (opts) => {
             outFile: result.opts.to,
         });
         let sassResult = sass.renderSync(options);
-        let parsed = await postcss.parse(sassResult.css.toString(), {
+        let ast = await postcss.parse(sassResult.css.toString(), {
             from: result.opts.from,
             map: sassResult.map && {
                 prev: JSON.parse(sassResult.map.toString()),
             },
         });
-        result.root = parsed;
+        ast.walkDecls((decl) => {
+            if (decl.value && decl.value.indexOf('url(') > -1) {
+                // correctly point url references
+                let consumer = decl.source.input.map.consumerCache;
+                let position = consumer.originalPositionFor(decl.source.start);
+                if (position.source) {
+                    // original file found for the rule
+                    let clone = decl.clone();
+                    clone.value = clone.value.replace(/url\(['"]?(.*?)['"]?\)/g, (full, url) => {
+                        if (url.match(/^(\w+:|\/\/)/)) {
+                            // ignore absolute and data urls
+                            return full;
+                        }
+                        let sourcePath = path.resolve(path.dirname(result.opts.to), position.source);
+                        let assetPath = path.resolve(path.dirname(sourcePath), url);
+                        let relative = path.relative(path.dirname(result.opts.to), assetPath);
+                        return full.replace(url, relative);
+                    });
+                    if (clone.value !== decl.value) {
+                        // update the declaration
+                        decl.replaceWith(clone);
+                    }
+                }
+            }
+        });
+        result.root = ast;
         result.dependencies = sassResult.stats.includedFiles;
     };
 });

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "mocha": "^5.2.0",
     "postcss": "^7.0.7",
     "postcss-all-unset": "^1.1.0",
+    "postcss-copy": "^7.1.0",
     "postcss-focus-visible": "^4.0.0",
     "postcss-focus-within": "^3.0.0",
     "postcss-scss": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7266,7 +7266,7 @@ micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.5:
+micromatch@^3.0.3, micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.5:
   version "3.1.10"
   resolved "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -8415,6 +8415,17 @@ postcss-convert-values@^4.0.1:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
+postcss-copy@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/postcss-copy/-/postcss-copy-7.1.0.tgz#1fee64421c5394451c0a094ecdc96a337779ff57"
+  integrity sha512-O3oGdW1pzEo2hvnKCFk1j4SYlfoeYELVFxJBP5ib/iAPqujJTumDRcxOtMucmpZNWfn5zqh8Hr4kiZUHtoEtUg==
+  dependencies:
+    micromatch "^3.0.3"
+    mkdirp "^0.5.1"
+    pify "^3.0.0"
+    postcss "^6.0.3"
+    postcss-value-parser "^3.3.0"
+
 postcss-discard-comments@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.1.tgz#30697735b0c476852a7a11050eb84387a67ef55d"
@@ -8765,7 +8776,7 @@ postcss@^5.0.2:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.13, postcss@^6.0.14:
+postcss@^6.0.13, postcss@^6.0.14, postcss@^6.0.3:
   version "6.0.23"
   resolved "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==


### PR DESCRIPTION
This PR aim to handle asset references in the css/scss files. When a relative `url()` being matched in the file, RNA will copy the asset into the assets directory.